### PR TITLE
Hide the search bar unless a user is logged in

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,7 @@
   </head>
   <body class="<%= render_body_class %>">
   <%= render :partial => 'shared/header_navbar' %>
+  <%= raw '<script> $("#search-navbar").hide(); </script>' if controller_name.in?(['sessions']) %>
 
   <%= render partial: 'shared/ajax_modal' %>
 


### PR DESCRIPTION
Trying to find a different solution for #204 that doesn't require pulling in the full blacklight navigation partials
