### PR TITLE
Text fixes

### DIFF
--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -16,7 +16,7 @@
     <% end %>
   </div>
   <p>
-    Trove is an interface that you can use to view image course collections of Tufts Art & Art History Department.
+    Trove is an interface that you can use to view image course collections of Tufts Art &amp; Art History Department.
     You can also create your own personal image collections for study purposes.  The <a href="/help">Help pages</a> describe
     in detail how to view, create and share collections in Trove.
 

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -1,6 +1,7 @@
 <div id="help" class="col-xs-12 col-sm-6 col-md-8">
   <!-- Edit this text in app/views/pages/about.html.erb -->
-  <h2>Using Trove</h2>
+  <h2>Help</h2>
+  <h3>Using Trove</h3>
 
   <p>Collections in Trove are available for use by Tufts University faculty and students, for teaching and research
     purposes. Initially, collections will include images selected by faculty for teaching Art History courses.  Faculty


### PR DESCRIPTION
@jcoyne this fixes the &amp; encoding in the homepage text, and moves the Help header up to the top of the page, nothing major, Alicia M. just wanted to move this text around on the help page.